### PR TITLE
browserify without sprockets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "react"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "es2015",
     "react"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /log/*
 !/log/.keep
 /tmp
+
+/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /tmp
 
 /node_modules/
+/public/client

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 /node_modules/
 /public/client
+/rev-manifest.yml

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,13 @@
 module ApplicationHelper
+
+  # render script tag for javascript built on node environment
+  # if no entry for 'path' in the manifest, tag should not be renderd
+  def built_javascript_include_tag(path)
+    manifest = Rails.application.config.assets.rev_manifest
+    return '' unless manifest && manifest[path].present?
+
+    host = Rails.application.config.action_controller.asset_host
+
+    javascript_include_tag("#{host}/client/builds/#{manifest[path]}")
+  end
 end

--- a/app/views/examples/show.html.slim
+++ b/app/views/examples/show.html.slim
@@ -1,2 +1,2 @@
-.div
-  | hoge
+h1 example
+.js-application-container

--- a/app/views/examples/show.html.slim
+++ b/app/views/examples/show.html.slim
@@ -1,4 +1,2 @@
 h1 example
 .js-application-container
-
-script src='/client/builds/examples/show_da77a47580.js'

--- a/app/views/examples/show.html.slim
+++ b/app/views/examples/show.html.slim
@@ -1,2 +1,4 @@
 h1 example
 .js-application-container
+
+script src='/client/builds/examples/show.js'

--- a/app/views/examples/show.html.slim
+++ b/app/views/examples/show.html.slim
@@ -1,4 +1,4 @@
 h1 example
 .js-application-container
 
-script src='/client/builds/examples/show.js'
+script src='/client/builds/examples/show_da77a47580.js'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,6 @@
 <body>
 
 <%= yield %>
-
+<%= built_javascript_include_tag "#{controller_path}/#{action_name}.js" %>
 </body>
 </html>

--- a/ci-client.sh
+++ b/ci-client.sh
@@ -1,0 +1,2 @@
+npm install
+npm test -- --reporter xunit --reporter-options output=tmp/reports/client-test-node-result.xml

--- a/client/enable-power-assert.js
+++ b/client/enable-power-assert.js
@@ -1,0 +1,3 @@
+require('espower-loader')({
+  pattern: 'client/**/*.js',
+});

--- a/client/lib/README.md
+++ b/client/lib/README.md
@@ -1,0 +1,1 @@
+for sctipts that are simple functions and used by gulp or command line node script

--- a/client/lib/gulp-js-build.js
+++ b/client/lib/gulp-js-build.js
@@ -1,0 +1,96 @@
+const browserify = require('browserify');
+const gulp = require('gulp');
+const gulpBuffer = require('gulp-buffer');
+const eventStream = require('event-stream');
+const gulpPlumber = require('gulp-plumber');
+const gulpUglify = require('gulp-uglify');
+const gulpUtil = require('gulp-util');
+const gulpRename = require('gulp-rename');
+const envify = require('envify/custom');
+
+/**
+ * simple log function used in pipeline
+ * @param {object} vinyl file object
+ */
+const printFilePath = (file, done) => {
+  gulpUtil.log( file.path );
+  done(null, file);
+};
+
+const bundler = (filepath, envifyOption = {}) => {
+  const b = browserify(filepath, {
+    extensions: ['.js', '.jsx']
+  });
+
+  b.transform(envify(envifyOption));
+
+  return b;
+};
+
+/**
+ * @param {Object} buildParam
+ * @param {Object} buildParam.jsSrcFiles 1st argument for gulp.src and list of entry points for browserify to bundle
+ * @param {string} buildParam.jsDestPath destination directory
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.isUglify] enable uglifing built js (default -> true
+ * @param {boolean} [options.isVerbose] enable verbose log in this task (default -> false
+ * @param {boolean} [options.exitOnError] enable to exit when error has occured in this taks (default -> false
+ * @param {string}  [options.nodeEnv] production or development default -> production
+ */
+module.exports = function(buildParam, options) {
+  var JS_SRC_FILES = buildParam.jsSrcFiles;
+  var JS_DEST_PATH = buildParam.jsDestPath;
+
+  options = Object.assign({
+    isUglify: true,
+    isVerbose: false,
+    exitOnError: true,
+    nodeEnv: 'production'
+  }, options);
+
+  var isUglify = options.isUglify;
+  var isVerbose = options.isVerbose;
+  var exitOnError = options.exitOnError;
+
+  return gulp.src(JS_SRC_FILES, {read: false})
+          .pipe(
+            exitOnError ?
+              gulpUtil.noop() :
+              gulpPlumber({
+                errorHandler (error) {
+                  gulpUtil.log(error.message);
+                  gulpUtil.log(error.stack);
+                  this.emit('end');
+                }
+              })
+          )
+          .pipe(eventStream.map((file, done) => {
+            gulpUtil.log('bundling ' + file.path);
+            // replace contents with browserify's bundle stream
+            bundler(file.path, {NODE_ENV: options.nodeEnv})
+              .bundle( (err, buf) => {
+                if (err) {
+                  done(err);
+                  return;
+                }
+
+                file.contents = buf;
+                gulpUtil.log(`done bundle ${file.path}`);
+                done(null, file);
+              });
+          }))
+          // convert into buffer contents
+          // since gulp-rev does not support streaming
+          .pipe(gulpBuffer())
+          .pipe(gulpRename({
+            extname: '.js'
+          }))
+          .pipe(isUglify ? gulpUglify() : gulpUtil.noop())
+          .on('error', (error) => {
+            gulpUtil.log(error);
+            throw error;
+          })
+          .pipe(isVerbose ? eventStream.map(printFilePath) : gulpUtil.noop())
+          .pipe(gulp.dest(JS_DEST_PATH));
+};

--- a/client/spec/examples/components/HelloExample.js
+++ b/client/spec/examples/components/HelloExample.js
@@ -1,0 +1,17 @@
+const assert = require('power-assert');
+const React = require('react');
+const { shallow } = require('enzyme');
+
+const HelloExample = require('../../../src/examples/components/HelloExample');
+describe('examples/components/HelloExample', function () {
+  it('render with h2', function () {
+    const wrapper = shallow( React.createElement( HelloExample ) );
+    assert.strictEqual(wrapper.find('h2').length, 1);
+    assert.strictEqual(wrapper.find('.hello-example--message').length, 0);
+  });
+
+  it('render with specified message by props', function () {
+    const wrapper = shallow( React.createElement( HelloExample, { message: 'my message' } ) );
+    assert.strictEqual(wrapper.find('.hello-example--message').text(), 'my message');
+  });
+});

--- a/client/spec/index.js
+++ b/client/spec/index.js
@@ -1,3 +1,13 @@
+const assert = require('power-assert');
 describe('index', () => {
-  it('empty');
+  it('random', () => {
+    const randomValue = ( max, min) => {
+      return Math.floor( Math.random() * (max - min) + min);
+    };
+
+    for(let i = 0 ; i < 1000 ; i++) {
+      const value = randomValue(150, 50);
+      assert.ok( 50 <= value && value < 150 );
+    }
+  });
 });

--- a/client/spec/index.js
+++ b/client/spec/index.js
@@ -1,0 +1,3 @@
+describe('index', () => {
+  it('empty');
+});

--- a/client/src/examples/components/HelloExample.jsx
+++ b/client/src/examples/components/HelloExample.jsx
@@ -1,0 +1,14 @@
+const React = require('react');
+
+const HelloExample = (props) => {
+  return (
+    <div>
+      <h2>hello example !!!</h2>
+      { props.message ?
+        <div className="hello-example--message">{props.message}</div> : null
+      }
+    </div>
+  );
+};
+
+module.exports = HelloExample;

--- a/client/src/examples/show.js
+++ b/client/src/examples/show.js
@@ -1,0 +1,12 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+const HelloExample = require('./components/HelloExample');
+
+window.document.addEventListener('DOMContentLoaded', () => {
+  const app = React.createElement( HelloExample, {message: 'hello world!'} );
+
+  const placement = window.document.querySelector('.js-application-container');
+
+  ReactDOM.render(app, placement);
+});

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,17 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # http://www.ohmyenter.com/how-to-do-something-on-reloading-on-rails/
+
+  # reload rev-manifest.yml when its updated
+  # @see also config/initializers/assets.rb
+  reloader = ActiveSupport::FileUpdateChecker.new(['rev-manifest.yml']) do
+    Rails.application.config.assets.rev_manifest = YAML.load_file('rev-manifest.yml') if File.exist?('rev-manifest.yml')
+  end
+  Rails.application.reloaders << reloader
+
+  ActionDispatch::Reloader.to_prepare do
+    reloader.execute_if_updated
+  end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+
+Rails.application.config.assets.rev_manifest = YAML.load_file('rev-manifest.yml') if File.exist?('rev-manifest.yml')

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,4 +10,5 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
 
+# @see also config/environments/development.rb
 Rails.application.config.assets.rev_manifest = YAML.load_file('rev-manifest.yml') if File.exist?('rev-manifest.yml')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,10 +10,12 @@ const ROOT = __dirname;
 const JS_SRC_FILES       = path.join(ROOT, 'client/src/**/*.*'); // watch target files
 const JS_SRC_ENTRY_FILES = path.join(ROOT, 'client/src/*/*.*'); // entry points of browserify
 const JS_DEST_PATH       = path.join(ROOT, 'public/client/builds'); // destination directory for built javasctipts
+const MANIFEST_FILE_PATH = path.join(ROOT, 'rev-manifest.yml');
 
 const jsBuildParams = {
   jsSrcFiles: [JS_SRC_ENTRY_FILES],
-  jsDestPath: JS_DEST_PATH
+  jsDestPath: JS_DEST_PATH,
+  manifestFilePath: MANIFEST_FILE_PATH
 };
 
 gulp.task('build:js:production', ['clean'], () => {
@@ -31,7 +33,8 @@ gulp.task('build:js:watch', ['clean'], () => {
 // delete manifest and bundled files
 gulp.task('clean', () => {
   return del([
-    JS_DEST_PATH
+    JS_DEST_PATH,
+    MANIFEST_FILE_PATH
   ]);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const del = require('del');
+const gulp = require('gulp');
+const path = require('path');
+
+const jsBuild = require('./client/lib/gulp-js-build.js');
+
+const ROOT = __dirname;
+const JS_SRC_FILES       = path.join(ROOT, 'client/src/**/*.*'); // watch target files
+const JS_SRC_ENTRY_FILES = path.join(ROOT, 'client/src/*/*.*'); // entry points of browserify
+const JS_DEST_PATH       = path.join(ROOT, 'public/client/builds'); // destination directory for built javasctipts
+
+const jsBuildParams = {
+  jsSrcFiles: [JS_SRC_ENTRY_FILES],
+  jsDestPath: JS_DEST_PATH
+};
+
+gulp.task('build:js:production', ['clean'], () => {
+  return jsBuild( jsBuildParams );
+});
+
+gulp.task('build:js:development', ['clean'], () => {
+  return jsBuild( jsBuildParams, { isUglify: false, nodeEnv: 'development' } );
+});
+
+gulp.task('build:js:watch', ['clean'], () => {
+  return jsBuild( jsBuildParams, { isUglify: false, exitOnError: false, isVerbose: true, nodeEnv: 'development' } );
+});
+
+// delete manifest and bundled files
+gulp.task('clean', () => {
+  return del([
+    JS_DEST_PATH
+  ]);
+});
+
+gulp.task('build:watch', ['build:js:watch']);
+gulp.task('build:development', ['build:js:development']);
+gulp.task('build:production', ['build:js:production']);
+gulp.task('build:test', ['build:production']);
+
+gulp.task('watch', ['build:development'], function(){
+  gulp.watch(JS_SRC_FILES, ['build:watch']);
+});

--- a/lib/tasks/npm.rake
+++ b/lib/tasks/npm.rake
@@ -1,0 +1,15 @@
+namespace :npm do
+  task :install do
+    sh "npm install"
+  end
+
+  task :build do
+    sh "npm run build:#{Rails.env}"
+  end
+end
+
+# assets:precompileのafter hookでjsをbuildする
+Rake::Task["assets:precompile"].enhance do
+  Rake::Task['npm:install'].invoke
+  Rake::Task['npm:build'].invoke
+end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "$(npm bin)/mocha client/spec --recursive"
   },
   "repository": {
     "type": "git",
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4/issues"
   },
-  "homepage": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4#readme"
+  "homepage": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4#readme",
+  "dependencies": {
+    "mocha": "^3.2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,20 @@
   },
   "scripts": {
     "test": "$(npm bin)/mocha client/spec --recursive  --compilers js:babel-register",
-    "test:power-assert": "$(npm bin)/mocha client/spec --recursive --require client/enable-power-assert.js --compilers js:babel-register"
+    "test:power-assert": "$(npm bin)/mocha client/spec --recursive --require client/enable-power-assert.js --compilers js:babel-register",
+    "build:development": "$(npm bin)/gulp build:development",
+    "build:test": "$(npm bin)/gulp build:test",
+    "build:production": "NODE_ENV=production $(npm bin)/gulp build:production",
+    "watch": "$(npm bin)/gulp watch"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4.git"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   },
   "author": "",
   "license": "ISC",
@@ -22,10 +31,21 @@
   },
   "homepage": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4#readme",
   "dependencies": {
+    "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",
     "babel-register": "^6.24.0",
+    "babelify": "^7.3.0",
+    "browserify": "^14.1.0",
+    "del": "^2.2.2",
+    "envify": "^4.0.0",
     "enzyme": "^2.7.1",
     "espower-loader": "^1.2.0",
+    "event-stream": "^3.3.4",
+    "gulp": "^3.9.1",
+    "gulp-buffer": "0.0.2",
+    "gulp-plumber": "^1.1.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-uglify": "^2.1.0",
     "mocha": "^3.2.0",
     "power-assert": "^1.4.2",
     "react": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -45,11 +45,14 @@
     "gulp-buffer": "0.0.2",
     "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
+    "gulp-rev": "^7.1.2",
+    "gulp-rev-format": "^1.0.4",
     "gulp-uglify": "^2.1.0",
     "mocha": "^3.2.0",
     "power-assert": "^1.4.2",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "yamljs": "^0.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "$(npm bin)/mocha client/spec --recursive"
+    "test": "$(npm bin)/mocha client/spec --recursive",
+    "test:power-assert": "$(npm bin)/mocha client/spec --recursive --require client/enable-power-assert.js"
   },
   "repository": {
     "type": "git",
@@ -21,6 +22,8 @@
   },
   "homepage": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4#readme",
   "dependencies": {
-    "mocha": "^3.2.0"
+    "espower-loader": "^1.2.0",
+    "mocha": "^3.2.0",
+    "power-assert": "^1.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "$(npm bin)/mocha client/spec --recursive",
-    "test:power-assert": "$(npm bin)/mocha client/spec --recursive --require client/enable-power-assert.js"
+    "test": "$(npm bin)/mocha client/spec --recursive  --compilers js:babel-register",
+    "test:power-assert": "$(npm bin)/mocha client/spec --recursive --require client/enable-power-assert.js --compilers js:babel-register"
   },
   "repository": {
     "type": "git",
@@ -22,8 +22,14 @@
   },
   "homepage": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4#readme",
   "dependencies": {
+    "babel-preset-react": "^6.23.0",
+    "babel-register": "^6.24.0",
+    "enzyme": "^2.7.1",
     "espower-loader": "^1.2.0",
     "mocha": "^3.2.0",
-    "power-assert": "^1.4.2"
+    "power-assert": "^1.4.2",
+    "react": "^15.4.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "example-browserify-without-sprockets-on-rails4",
+  "private": false,
+  "version": "1.0.0",
+  "description": "== README",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4/issues"
+  },
+  "homepage": "https://github.com/OsugaHiroshi/example-browserify-without-sprockets-on-rails4#readme"
+}


### PR DESCRIPTION
# see also
- https://github.com/browserify-rails/browserify-rails
- https://github.com/rails/webpacker

# Summary
We got normal javascript development environment out side of sprockets on Rails4 application

# Goals
- developing javascripts with a normal javascript tool belt and libraries
- automatic rendering of script tag by controller/action name
- enable cache busting
- integrate a javascripts building process into deployment process
- smooth development
- ci in node environment

# Using a javascript tool belt and libraries
We simply executed `npm init` in the root rails directory and decided most of files put under `client` directory.

- e82b020
- 3494b30
- 4a85c2c
- b20d054

# Detecting a javascript file and cache busting

## Directory layout and entrypoints
Before creating a tool chain to build javascripts, we decided that a javascript entry point per controller/action is one file for maintainance reason and `public/client/builds` directory is a destination of built javascripts.

So the directory layout is following.
```
- public/client/builds/{controller_name}/{action_name}.js
- client/src/{controller_name}/
    - {action_name}.js
    - other_directories_for_this_controller
```

After that, we created the process to build javascripts with gulp.
- ba95b11
- 81b2978

For example `client/src/examples/show.js` is built and placed in`public/client/builds/examples/show.js`.

If cache busting is not required, it will be ready to be loaded on the page with a simple application helper method.

## Hashing and mapping filename
If hash value is included in the file name for cache busting, rails needs to know the current hash value to render a script tag.
Therefore, `rev-manifest.yml` exists to map controller/action name to file path including hash.

Both adding hash and make `rev-manifest.yml` are done at the same time in the build process.

- 28cb314
- 038931b

# Build in deployment
When deploying rails application, javascript files also must be built. 
Since we already have been running several rake tasks at deployment, we hooked it after `assets:precompile`.

- f35d049

# Smooth development
Usually `rev-manifest.yml` is loaded by `config/initializers/assets.rb` because of its not updated during rails application is running, but it is updated more frequently during development

Since it is very stressful to restart rails application every `rev-manifest.yml` is updated, its update was watched by `ActiveSupport::FileUpdateChecker` and it is reloaded.

In the result, we are running `bundle exec rails s` and `npm run watch` during development.

- 42b1070

# CI
Because of these actions, unit test already can be executable in command line and there was no technical problem. 
I knew that it can be incorporated in jenkins by adding a few options to `npm test`.

- c579502

# Conclusion
All our goals were achieved these efforts.
Most important thing is that we got more chances to try new tool, new library and new architecture 